### PR TITLE
Remove old references to Liikennevirasto / Finnish Transport Agency

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ the method is described in a tutorial [video on YouTube](https://www.youtube.com
 
 After that, the letters were copied one by one to *Glyphs* app and scaled with same proportions.
 
-Spacing of the typeface was done using the original [spacing tables, from page 287->](https://julkaisut.liikennevirasto.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf).
+Spacing of the typeface was done using the original [spacing tables, from page 287->](https://julkaisut.vayla.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf).
 
 Kerning tables aren't done, as I felt a bit unmotivated since the original kerning is somewhat bad.
 
@@ -78,9 +78,9 @@ I was brave enough to fix some of the problems that exist in the original typefa
 ## Existing problems and issues (TODO)
 
 * Artefacts from the originals should be removed and fixed
-* Kerning is not done (feel free to contribute, the information exists is [on page 293->](https://julkaisut.liikennevirasto.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf))
+* Kerning is not done (feel free to contribute, the information exists is [on page 293->](https://julkaisut.vayla.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf))
 * Some curves aren't curves - they have angular shapes
-* Missing: Cyrillics and their spacing, [from page 298->](https://julkaisut.liikennevirasto.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf)
+* Missing: Cyrillics and their spacing, [from page 298->](https://julkaisut.vayla.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf)
 
 ## Major improvement ideas - How to make Tie actually work for traffic signs
 
@@ -105,7 +105,7 @@ I was brave enough to fix some of the problems that exist in the original typefa
 
 ## References
 
-* [Liikennemerkkipiirustukset](https://julkaisut.liikennevirasto.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf)
+* [Liikennemerkkipiirustukset](https://julkaisut.vayla.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf)
 * [Liikennevirasto on Flickr (lots of traffic signs)](https://www.flickr.com/photos/liikennevirasto/albums/with/72157660385178002)
 * [Opastemerkkien Luettavuus - Tiehallinto (2005)](https://julkaisut.liikennevirasto.fi/pdf/3200927-vopastusmerkkienluettavuu.pdf)
 * [Tobias Frere-Jones' Retina Typeface for Maximum Legibility of The Wall Street Journal](http://www.howdesign.com/design-business/design-news/retina-typeface-frere-jones-type/)

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Suomalaisissa liikennemerkeissä käytetyn kirjasintyypin fontti-konversio alkup
 
 ### Lisätietoja
 
-[Lue lisää Wikipediasta](https://fi.wikipedia.org/wiki/Liikennemerkit_Suomessa) ja [Liikenneviraston sivuilta](https://www.liikennevirasto.fi/avoindata/tietoaineistot/liikennemerkkien-kirjasintyyppi).
+[Lue lisää Wikipediasta](https://fi.wikipedia.org/wiki/Liikennemerkit_Suomessa) ja [Väyläviraston sivuilta](https://vayla.fi/avoindata/tieverkko/liikennemerkkien-kirjasintyyppi).
 
 ![Example of STOP Sign with standard spacing](./examples/stop.png "Example of STOP Sign with standard spacing")
 
 ## Preface
 
-The Finnish traffic sign typeface contains a lot of errors and problems. I ended up asking about the typeface used for upcoming renewed signs from Liikennevirasto, and the conversation in Twitter lead to a CC0 release of the original typeface drawn in 1960's.
+The Finnish traffic sign typeface contains a lot of errors and problems. I ended up asking about the typeface used for upcoming renewed signs from Finnish Transport Agency (currently Finnish Transport Infrastructure Agency), and the conversation in Twitter lead to a CC0 release of the original typeface drawn in 1960's.
 
-*Tie*  is a typeface conversion of the original Finnish traffic sign typeface that is available at [Liikennevirasto page](https://www.liikennevirasto.fi/avoindata/tietoaineistot/liikennemerkkien-kirjasintyyppi).
+*Tie*  is a typeface conversion of the original Finnish traffic sign typeface that is available at [Finnish Transport Infrastructure Agency page](https://vayla.fi/avoindata/tieverkko/liikennemerkkien-kirjasintyyppi).
 
 ## Usage / Installation
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ I was brave enough to fix some of the problems that exist in the original typefa
 
 * [Liikennemerkkipiirustukset](https://julkaisut.vayla.fi/thohje/pdf/liikennemerkkipiirustukset_osa2_19092013.pdf)
 * [Liikennevirasto on Flickr (lots of traffic signs)](https://www.flickr.com/photos/liikennevirasto/albums/with/72157660385178002)
-* [Opastemerkkien Luettavuus - Tiehallinto (2005)](https://julkaisut.liikennevirasto.fi/pdf/3200927-vopastusmerkkienluettavuu.pdf)
+* [Opastemerkkien Luettavuus - Tiehallinto (2005)](https://julkaisut.vayla.fi/pdf/3200927-vopastusmerkkienluettavuu.pdf)
 * [Tobias Frere-Jones' Retina Typeface for Maximum Legibility of The Wall Street Journal](http://www.howdesign.com/design-business/design-news/retina-typeface-frere-jones-type/)
 * [Designing the ultimate Wayfinding Typeface](https://typography.guru/journal/designing-the-ultimate-wayfinding-typeface-r30/)
 


### PR DESCRIPTION
The Finnish Transport Agency is now the Finnish Transport Infrastructure Agency (in Finnish, Väylä)